### PR TITLE
introduce travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - 10
+
+cache:
+  yarn: true
+  directories:
+    - node_modules
+


### PR DESCRIPTION
Introduces Travis CI for continuous integration and testing. Enable by following step [one through three](https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci) of the official instructions.
