### PR TITLE
introduce trivial dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# -- trivial container for bgpalerter
+FROM node:10-alpine as build
+
+WORKDIR /opt/bgpalerter
+COPY . .
+
+RUN yarn
+
+ENTRYPOINT ["npm"]
+CMD ["run", "serve"]


### PR DESCRIPTION
Introduce a trivial but fully functional Dockerfile. No documentation yet, as automatic builds to Docker Hub haven't been enabled yet, and instructions should probably reference the 'official' docker image. Docker Hub automatic builds can be enabled by following the [instructions](https://docs.docker.com/docker-hub/builds/).