### PR TITLE
selectively include or exclude monitors for specific prefixes

### DIFF
--- a/connectors/connectorTest.js
+++ b/connectors/connectorTest.js
@@ -175,6 +175,17 @@ export default class ConnectorTest extends Connector{
                                 path: [1, 2, 3, 1345]
                             },
                             type: "ris_message"
+                        },
+                        {
+                            data: {
+                                announcements: [{
+                                    prefixes: ["175.254.205.0/25", "170.254.205.0/25"],
+                                    next_hop: "124.0.0.3"
+                                }],
+                                peer: "124.0.0.3",
+                                path: [1, 2, 3, 1234]
+                            },
+                            type: "ris_message"
                         }
                     ];
                     break;

--- a/inputs/inputYml.js
+++ b/inputs/inputYml.js
@@ -78,6 +78,8 @@ export default class InputYml extends Input {
                             prefix: i,
                             group: 'default',
                             ignore: false,
+                            excludeMonitors: [],
+                            includeMonitors: [],
                         }, monitoredPrefixesFile[i])
                     })
                     .filter(i => i !== null);
@@ -99,7 +101,7 @@ export default class InputYml extends Input {
                 const item = fileContent[prefix];
                 let asns;
 
-                if (!prefix || !ipUtils.isValidPrefix(prefix)){
+                if (!prefix || !ipUtils.isValidPrefix(prefix)) {
                     return "Not a valid prefix: " + prefix;
                 }
 
@@ -111,16 +113,33 @@ export default class InputYml extends Input {
                     return "Not a valid AS number for: " + prefix;
                 }
 
-                if (asns.some(asn => !asn || !new AS(asn).isValid())){
+                if (asns.some(asn => !asn || !new AS(asn).isValid())) {
                     return "Not a valid AS number for: " + prefix;
                 }
 
-                if (!["string", "number"].includes(typeof(item.description))){
+                if (!["string", "number"].includes(typeof(item.description))) {
                     return "Not a valid description for: " + prefix;
                 }
 
-                if (typeof(item.ignoreMorespecifics) !== "boolean"){
+                if (typeof(item.ignoreMorespecifics) !== "boolean") {
                     return "Not a valid ignoreMorespecifics value for: " + prefix;
+                }
+
+                if (item.ignore !== undefined && typeof(item.ignore) !== "boolean") {
+                    return "Not a valid ignore value for: " + prefix;
+                }
+
+                if (item.includeMonitors !== undefined && item.excludeMonitors !== undefined) {
+                    return "You can define only one of includeMonitor or excludeMonitor for: " + prefix;
+
+                }
+
+                if (item.excludeMonitors !== undefined && !Array.isArray(item.excludeMonitors)) {
+                    return "Not a valid excludeMonitor value for: " + prefix;
+                }
+
+                if (item.includeMonitors !== undefined && !Array.isArray(item.includeMonitors)) {
+                    return "Not a valid includeMonitor value for: " + prefix;
                 }
 
                 return null;

--- a/monitors/monitor.js
+++ b/monitors/monitor.js
@@ -175,6 +175,18 @@ export default class Monitor {
         this.pubSub.publish(this.channel, alert);
 
         return alert;
-    }
+    };
+
+    getMoreSpecificMatch = (prefix) => {
+        const matched = this.input.getMoreSpecificMatch(prefix);
+
+        if (matched) {
+            if (matched.includeMonitors.length > 0 && !matched.includeMonitors.includes(this.name)) {
+                return null;
+            }
+
+            return (matched.excludeMonitors.includes(this.name)) ? null : matched;
+        }
+    };
 
 }

--- a/monitors/monitorHijack.js
+++ b/monitors/monitorHijack.js
@@ -54,7 +54,7 @@ export default class MonitorHijack extends Monitor {
         new Promise((resolve, reject) => {
 
             const messagePrefix = message.prefix;
-            const matchedRule = this.input.getMoreSpecificMatch(messagePrefix);
+            const matchedRule = this.getMoreSpecificMatch(messagePrefix);
 
             if (matchedRule && !matchedRule.asn.includes(message.originAS)) {
                 const asnText = matchedRule.asn;

--- a/monitors/monitorNewPrefix.js
+++ b/monitors/monitorNewPrefix.js
@@ -55,7 +55,7 @@ export default class MonitorNewPrefix extends Monitor {
         new Promise((resolve, reject) => {
 
             const messagePrefix = message.prefix;
-            const matchedRule = this.input.getMoreSpecificMatch(messagePrefix);
+            const matchedRule = this.getMoreSpecificMatch(messagePrefix);
 
             if (matchedRule && matchedRule.asn.includes(message.originAS) && matchedRule.prefix !== messagePrefix) {
                 const text = `Possible change of configuration. A new prefix ${message.prefix} is announced by ${message.originAS}. It is a more specific of ${matchedRule.prefix} (${matchedRule.description}).`;

--- a/monitors/monitorVisibility.js
+++ b/monitors/monitorVisibility.js
@@ -67,7 +67,7 @@ export default class MonitorVisibility extends Monitor {
         new Promise((resolve, reject) => {
 
             const messagePrefix = message.prefix;
-            const matchedRule = this.input.getMoreSpecificMatch(messagePrefix);
+            const matchedRule = this.getMoreSpecificMatch(messagePrefix);
 
             if (matchedRule && matchedRule.prefix === messagePrefix) {
 

--- a/tests/prefixes.test.yml
+++ b/tests/prefixes.test.yml
@@ -35,3 +35,20 @@
   asn: 1234
   ignore: true
   ignoreMorespecifics: true
+
+175.254.205.0/24:
+  description: include exclude test
+  asn: 1234
+  ignoreMorespecifics: false
+  ignore: false
+  excludeMonitors:
+    - basic-hijack-detection
+    - withdrawal-detection
+
+170.254.205.0/24:
+  description: include exclude test
+  asn: 1234
+  ignoreMorespecifics: false
+  ignore: false
+  includeMonitors:
+    - prefix-detection

--- a/tests/test.js
+++ b/tests/test.js
@@ -130,7 +130,7 @@ describe("Tests", function() {
 
         it("loading prefixes", function () {
 
-            expect(env.input.prefixes.length).to.equal(7);
+            expect(env.input.prefixes.length).to.equal(9);
             expect(JSON.parse(JSON.stringify(env.input))).to
                 .containSubset({
                     "prefixes": [
@@ -140,7 +140,9 @@ describe("Tests", function() {
                             "ignoreMorespecifics": false,
                             "prefix": "165.254.225.0/24",
                             "group": "default",
-                            "ignore": false
+                            "ignore": false,
+                            "excludeMonitors" : [],
+                            "includeMonitors": []
                         },
                         {
                             "asn": [15562],
@@ -148,7 +150,9 @@ describe("Tests", function() {
                             "ignoreMorespecifics": false,
                             "prefix": "165.254.255.0/24",
                             "group": "default",
-                            "ignore": false
+                            "ignore": false,
+                            "excludeMonitors" : [],
+                            "includeMonitors": []
                         },
                         {
                             "asn": [15562],
@@ -156,7 +160,9 @@ describe("Tests", function() {
                             "ignoreMorespecifics": true,
                             "prefix": "192.147.168.0/24",
                             "group": "default",
-                            "ignore": false
+                            "ignore": false,
+                            "excludeMonitors" : [],
+                            "includeMonitors": []
                         },
                         {
                             "asn": [204092, 45],
@@ -164,7 +170,9 @@ describe("Tests", function() {
                             "ignoreMorespecifics": false,
                             "prefix": "2a00:5884::/32",
                             "group": "default",
-                            "ignore": false
+                            "ignore": false,
+                            "excludeMonitors" : [],
+                            "includeMonitors": []
                         },
                         {
                             "asn": [208585],
@@ -172,7 +180,9 @@ describe("Tests", function() {
                             "ignoreMorespecifics": false,
                             "prefix": "2a0e:f40::/29",
                             "group": "default",
-                            "ignore": false
+                            "ignore": false,
+                            "excludeMonitors" : [],
+                            "includeMonitors": []
                         },
                         {
                             "asn": [1234],
@@ -180,7 +190,9 @@ describe("Tests", function() {
                             "ignoreMorespecifics": true,
                             "prefix": "2a0e:f40::/30",
                             "group": "default",
-                            "ignore": false
+                            "ignore": false,
+                            "excludeMonitors" : [],
+                            "includeMonitors": []
                         },
                         {
                             "asn": [1234],
@@ -188,7 +200,29 @@ describe("Tests", function() {
                             "ignoreMorespecifics": true,
                             "prefix": "2a0e:240::/32",
                             "group": "default",
-                            "ignore": true
+                            "ignore": true,
+                            "excludeMonitors" : [],
+                            "includeMonitors": []
+                        },
+                        {
+                            "asn": [1234],
+                            "description": "include exclude test",
+                            "ignoreMorespecifics": false,
+                            "prefix": "175.254.205.0/24",
+                            "group": "default",
+                            "ignore": false,
+                            "excludeMonitors" : ["basic-hijack-detection", "withdrawal-detection"],
+                            "includeMonitors": []
+                        },
+                        {
+                            "asn": [1234],
+                            "description": "include exclude test",
+                            "ignoreMorespecifics": false,
+                            "prefix": "170.254.205.0/24",
+                            "group": "default",
+                            "ignore": false,
+                            "excludeMonitors" : [],
+                            "includeMonitors": ["prefix-detection"]
                         }
                     ]
                 });
@@ -310,8 +344,6 @@ describe("Tests", function() {
 
         }).timeout(10000);
 
-
-
         it("hijack reporting", function(done) {
 
             pubSub.publish("test-type", "hijack");
@@ -426,12 +458,67 @@ describe("Tests", function() {
 
         }).timeout(10000);
 
-
         it("newprefix reporting", function (done) {
 
             pubSub.publish("test-type", "newprefix");
 
             const expectedData = {
+                "1234-175.254.205.0/25": {
+                    id: '1234-175.254.205.0/25',
+                    origin: 'prefix-detection',
+                    affected: 1234,
+                    message: 'Possible change of configuration. A new prefix 175.254.205.0/25 is announced by AS1234. It is a more specific of 175.254.205.0/24 (include exclude test).',
+                    data: [
+                        {
+                            extra: {},
+                            matchedRule: {
+                                prefix: '175.254.205.0/24',
+                                group: 'default',
+                                description: 'include exclude test',
+                                asn: [1234],
+                                ignoreMorespecifics: false,
+                                ignore: false,
+                                excludeMonitors: ["basic-hijack-detection", "withdrawal-detection"]
+                            },
+                            matchedMessage: {
+                                type: 'announcement',
+                                prefix: '175.254.205.0/25',
+                                peer: '124.0.0.3',
+                                path: [ 1, 2, 3, 1234 ],
+                                originAS: [1234],
+                                nextHop: '124.0.0.3'
+                            }
+                        }
+                    ]
+                },
+                "1234-170.254.205.0/25": {
+                    id: '1234-170.254.205.0/25',
+                    origin: 'prefix-detection',
+                    affected: 1234,
+                    message: 'Possible change of configuration. A new prefix 170.254.205.0/25 is announced by AS1234. It is a more specific of 170.254.205.0/24 (include exclude test).',
+                    data: [
+                        {
+                            extra: {},
+                            matchedRule: {
+                                prefix: '170.254.205.0/24',
+                                group: 'default',
+                                description: 'include exclude test',
+                                asn: [1234],
+                                ignoreMorespecifics: false,
+                                includeMonitors: ["prefix-detection"],
+                                ignore: false
+                            },
+                            matchedMessage: {
+                                type: 'announcement',
+                                prefix: '170.254.205.0/25',
+                                peer: '124.0.0.3',
+                                path: [ 1, 2, 3, 1234 ],
+                                originAS: [1234],
+                                nextHop: '124.0.0.3'
+                            }
+                        }
+                    ]
+                },
                 "15562-165.254.255.0/25":
                     {
                         id: '15562-165.254.255.0/25',
@@ -496,7 +583,6 @@ describe("Tests", function() {
 
                 expect(Object.keys(expectedData).includes(id)).to.equal(true);
                 expect(expectedData[id] != null).to.equal(true);
-
 
                 expect(message).to
                     .containSubset(expectedData[id]);


### PR DESCRIPTION
* introduced two new attributes for monitored prefixes includeMonitors and excludeMonitors
* both attributes are array of string and they can be populated with monitors names
* if includeMonitors is used, the prefix will be only monitored with the specific monitor(s)
* if excludeMonitors is used, all monitors except the escluded ones will monitor the prefix
* only one of the two options can be set
* if the options are not declared, all monitors will be used