### PR TITLE
Fix typo in docs/prefixes.md

### DIFF
--- a/docs/prefixes.md
+++ b/docs/prefixes.md
@@ -33,7 +33,7 @@ The prefix list is a file containing a series of blocks like the one below, one 
   description: Rome peering
   asn: 2914
   ignoreMorespecifics: false
-  ignore: false,
+  ignore: false
   group: aUserGroup
   excludeMonitors:
     - withdrawal-detection


### PR DESCRIPTION
There was an extra comma on the end of this ignore line that I removed.