### PR TITLE
updates case of monitorAS

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -38,7 +38,7 @@ monitors:
     params:
       thresholdMinPeers: 10
 
-  - file: MonitorAS
+  - file: monitorAS
     channel: misconfiguration
     name: asn-monitor
     params:


### PR DESCRIPTION
enabling this option with the supplied example config would error out that MonitorAS.js couldn't be found, the others were lowercase, this fixed the issue for me.