### PR TITLE
Rework ignored prefixes to also exclude during AS monitoring

### DIFF
--- a/src/inputs/input.js
+++ b/src/inputs/input.js
@@ -90,7 +90,7 @@ export default class Input {
 
         for (let p of this.prefixes) {
             if (p.prefix === prefix) {
-                return (p.ignore) ? null : p;
+                return p;
             } else {
                 if (!this.cache[p.prefix]) {
                     this.cache[p.prefix] = ipUtils.getNetmask(p.prefix);

--- a/src/monitors/monitorHijack.js
+++ b/src/monitors/monitorHijack.js
@@ -64,7 +64,7 @@ export default class MonitorHijack extends Monitor {
             const messagePrefix = message.prefix;
             const matchedRule = this.getMoreSpecificMatch(messagePrefix);
 
-            if (matchedRule && !matchedRule.asn.includes(message.originAS)) {
+            if (matchedRule && !matchedRule.ignore && !matchedRule.asn.includes(message.originAS)) {
                 const asnText = matchedRule.asn;
 
                 const text = (message.prefix === matchedRule.prefix) ?

--- a/src/monitors/monitorNewPrefix.js
+++ b/src/monitors/monitorNewPrefix.js
@@ -64,7 +64,7 @@ export default class MonitorNewPrefix extends Monitor {
             const messagePrefix = message.prefix;
             const matchedRule = this.getMoreSpecificMatch(messagePrefix);
 
-            if (matchedRule && matchedRule.asn.includes(message.originAS) && matchedRule.prefix !== messagePrefix) {
+            if (matchedRule && !matchedRule.ignore && matchedRule.asn.includes(message.originAS) && matchedRule.prefix !== messagePrefix) {
                 const text = `Possible change of configuration. A new prefix ${message.prefix} is announced by ${message.originAS}. It is a more specific of ${matchedRule.prefix} (${matchedRule.description}).`;
 
                 this.publishAlert(message.originAS.getId() + "-" + message.prefix,

--- a/src/monitors/monitorPath.js
+++ b/src/monitors/monitorPath.js
@@ -66,7 +66,7 @@ export default class MonitorPath extends Monitor {
             const messagePrefix = message.prefix;
             const matchedRule = this.getMoreSpecificMatch(messagePrefix);
 
-            if (matchedRule && matchedRule.path) {
+            if (matchedRule && !matchedRule.ignore && matchedRule.path) {
                 const pathString = message.path.getValues().join(",");
 
                 let expMatch = true;

--- a/src/monitors/monitorVisibility.js
+++ b/src/monitors/monitorVisibility.js
@@ -76,7 +76,7 @@ export default class MonitorVisibility extends Monitor {
             const messagePrefix = message.prefix;
             const matchedRule = this.getMoreSpecificMatch(messagePrefix);
 
-            if (matchedRule && matchedRule.prefix === messagePrefix) {
+            if (matchedRule && !matchedRule.ignore && matchedRule.prefix === messagePrefix) {
 
                 let key = matchedRule.prefix;
 


### PR DESCRIPTION
I believe this should fix #100;

Currently if a monitor is looking for a missing prefix it cannot rely upon the implementation of getMoreSpecificMatch.

At the time getMoreSpecificMatch was written, excluding all ignored prefixes made sense as there was no monitor for missing prefixes,
however now it excludes prefixes that we have a configuration match for, but desire to exclude from monitoring.

The primary purposes of this is for monitorAS *not* to respect the prefix's `ignore` attribute,
ensureing that we do not emit un-configured messages for a prefix that has explicitly been 'ignored in monitoring'.

Hopefully this ensures the current documentation (`Exclude the current prefix from monitoring. Useful when you are monitoring a prefix and you want to exclude a particular sub-prefix`) now reflects reality.