### PR TITLE
reportHTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Read the documentation below for more options.
             - [reportSyslog](docs/configuration.md#reportsyslog)
             - [reportAlerta](docs/configuration.md#reportalerta)
             - [reportWebex](docs/configuration.md#reportwebex)
+            - [reportHTTP](docs/configuration.md#reporthttp)
     - [Process/Uptime monitoring](docs/process-monitors.md)
     - [Notification user groups](docs/usergroups.md)
 - [More information for developers](docs/develop.md)

--- a/config.yml.example
+++ b/config.yml.example
@@ -125,7 +125,7 @@ reports:
 #    params:
 #      host: localhost
 #      port: 514
-#      templates:
+#      templates: # See here how to write a template https://github.com/nttgin/BGPalerter/blob/master/docs/context.md
 #        default: "++BGPalerter-3-${type}: ${summary}|${earliest}|${latest}"
 #        hijack: "++BGPalerter-5-${type}: ${summary}|${prefix}|${description}|${asn}|${newprefix}|${neworigin}|${earliest}|${latest}|${peers}"
 #        newprefix: "++BGPalerter-4-${type}: ${summary}|${prefix}|${description}|${asn}|${newprefix}|${neworigin}|${earliest}|${latest}|${peers}"
@@ -145,7 +145,7 @@ reports:
 #        newprefix: informational
 #        visibility: debug
 #        path: trace
-#      resourceTemplates:
+#      resourceTemplates: # See here how to write a template https://github.com/nttgin/BGPalerter/blob/master/docs/context.md
 #        default: "${type}"
 #        hijack: "hijack::${prefix}@@${asn}"
 #        newprefix: "newprefix::${prefix}@@${asn}"
@@ -171,7 +171,7 @@ reports:
 #      - path
 #      - misconfiguration
 #    params:
-#      templates:
+#      templates: # See here how to write a template https://github.com/nttgin/BGPalerter/blob/master/docs/context.md
 #        default: '{"text": "${summary}"}'
 #      headers:
 #      isTemplateJSON: true

--- a/config.yml.example
+++ b/config.yml.example
@@ -163,6 +163,21 @@ reports:
 #      hooks:
 #        default: _YOUR_WEBEX_WEBHOOK_URL_
 
+#  - file: reportHTTP
+#    channels:
+#      - hijack
+#      - newprefix
+#      - visibility
+#      - path
+#      - misconfiguration
+#    params:
+#      templates:
+#        default: '{"text": "${summary}"}'
+#      headers:
+#      isTemplateJSON: true
+#      showPaths: 0 # Amount of AS_PATHs to report in the alert
+#      hooks:
+#        default: _YOUR_WEBHOOK_URL_
 
 ############################
 # Notification settings:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,7 +342,7 @@ Parameters for this report module:
 |environment| The Alerta environment name. If not specified, it'll use the BGPalerter environment name. |
 |key| Optional, the Alerta API key to use for authenticated requests. |
 |token| Optional value used when executing HTTP requests to the Alerta API with bearer authentication. |
-|resource_templates| A dictionary of string templates for each BGPalerter channels to generate the content of the `resource` field for the alert. If a channel doesn't have a template defined, the `default` template will be used (see `config.yml.example` for more details). |
+|resourceTemplates| A dictionary of string templates for each channels to generate the content of the `resource` field for the alert. If a channel doesn't have a template defined, the `default` template will be used (see `config.yml.example` for more details). Read [here](context.md) how to write a template.|
 |urls| A dictionary containing Alerta API URLs grouped by user group (key: group, value: API URL). |
 |urls.default| The Alerta API URL of the default user group. |
 
@@ -359,4 +359,20 @@ Parameters for this report module:
 |---|---|
 |hooks| A dictionary containing Webex Teams WebHooks grouped by user group (key: group, value: WebHook).| 
 |hooks.default| The WebHook (URL) of the default user group.| 
+
+#### reportHTTP
+
+This report module sends alerts on a generic HTTP end-point.
+
+Parameters for this report module:
+
+|Parameter| Description| 
+|---|---|
+|hooks| A dictionary containing API URLs grouped by user group (key: group, value: URL).| 
+|hooks.default| The URL of the default user group.| 
+|templates| A dictionary containing string templates for each channels. If a channel doesn't have a template defined, the `default` template will be used (see `config.yml.example` for more details). Read [here](context.md) how to write a template. |
+|isTemplateJSON| A boolean defining if the template provided above are JSON or plain string |
+|headers| Additional headers to use in the GET request. For example for authentication.|
+|showPaths| Amount of AS_PATHs to report in the alert (0 to disable). | 
+
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -1,0 +1,24 @@
+# Report context      
+
+All the report modules inherit the method `getContext` from the super class `Report`. This method returns a dictionary with some pre-computed tags useful for composing textual reports.
+Such tags are reported in the table below.
+
+| Tag | Description | 
+|---|---|
+| summary | The summary of the alert |
+| earliest | The date of the earliest event that triggered the alert (format YYYY-MM-DD hh:mm:ss)|
+| latest | The date of the last event that triggered the alert (format YYYY-MM-DD hh:mm:ss)|
+| channel | The channel where the alert is coming from |
+| type | The name of the monitor that triggered the alert |
+| prefix | The monitored prefix involved in the alert |
+| description | The description of the prefix involved in the alert |
+| asn | The monitored AS involved in the alert |
+| peers | The number of peers that were able to see the issue |
+| neworigin | The AS announcing the monitored prefix (e.g. in case of a hijack, `neworigin` will contain the hijacker, `asn` will contain the usual origin) |
+| newprefix | The prefix announced (e.g. in case of a hijack, `newprefix` will contain the more specific prefix used for the hijack, `prefix` will contain the usual prefix) |
+| bgplay | The link to BGPlay on RIPEstat |
+
+
+Usage example: `The alert involves ${prefix} in ${earliest}` will be translated in something like `The alert involves 1.2.3.4/24 in 2020-04-14 04:02:13`.
+
+> The same approach must be used to populate the templates available in config.yml. If you are writing a template for an API call, convert the JSON to string (e.g. '{"text": "${summary}"}').

--- a/src/monitors/monitorRPKI.js
+++ b/src/monitors/monitorRPKI.js
@@ -17,6 +17,10 @@ export default class MonitorRPKI extends Monitor {
 
     };
 
+    updateMonitoredResources = () => {
+        // nothing
+    };
+
     validateBatch = () => {
         const queue = this.validationQueue;
         this.validationQueue = [];

--- a/src/reports/reportHTTP.js
+++ b/src/reports/reportHTTP.js
@@ -38,19 +38,19 @@ export default class ReportHTTP extends Report {
     constructor(channels, params, env) {
         super(channels, params, env);
 
-
+        this.name = "reportHTTP" || this.params.name;
         this.enabled = true;
         if (!this.params.hooks || !Object.keys(this.params.hooks).length){
             this.logger.log({
                 level: 'error',
-                message: "HTTP reporting is not enabled: no group is defined"
+                message: `${this.name} reporting is not enabled: no group is defined`
             });
             this.enabled = false;
         } else {
             if (!this.params.hooks["default"]) {
                 this.logger.log({
                     level: 'error',
-                    message: "In hooks, for reportHTTP, a group named 'default' is required for communications to the admin."
+                    message: `In hooks, for ${this.name}, a group named 'default' is required for communications to the admin.`
                 });
             }
         }

--- a/src/reports/reportHTTP.js
+++ b/src/reports/reportHTTP.js
@@ -1,0 +1,105 @@
+/*
+ * 	BSD 3-Clause License
+ *
+ * Copyright (c) 2019, NTT Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Report from "./report";
+import axios from "axios";
+
+export default class ReportHTTP extends Report {
+
+    constructor(channels, params, env) {
+        super(channels, params, env);
+
+
+        this.enabled = true;
+        if (!this.params.hooks || !Object.keys(this.params.hooks).length){
+            this.logger.log({
+                level: 'error',
+                message: "HTTP reporting is not enabled: no group is defined"
+            });
+            this.enabled = false;
+        } else {
+            if (!this.params.hooks["default"]) {
+                this.logger.log({
+                    level: 'error',
+                    message: "In hooks, for reportHTTP, a group named 'default' is required for communications to the admin."
+                });
+            }
+        }
+
+        this.headers = this.params.headers || {};
+        if (this.params.isTemplateJSON) {
+            this.headers["Content-Type"] = "application/json";
+        }
+    }
+
+
+    _getMessage = (channel, content) => {
+        return this.parseTemplate(this.params.templates[channel] || this.params.templates["default"], this.getContext(channel, content));
+    };
+
+    _sendHTTPMessage = (url, channel, content) => {
+        content = JSON.parse(JSON.stringify(content));
+        if (this.params.showPaths > 0) {
+            content.message += `${content.message}. Top ${context.pathNumber} most used AS paths: \n ${context.paths}`;
+        }
+
+        const blob = this._getMessage(channel, content);
+
+        axios({
+            url: url,
+            method: "POST",
+            headers: this.headers,
+            data: (this.params.isTemplateJSON) ? JSON.parse(blob) : blob
+        })
+            .catch((error) => {
+                this.logger.log({
+                    level: 'error',
+                    message: error
+                });
+            })
+    };
+
+    report = (channel, content) => {
+        if (this.enabled) {
+            let groups = content.data.map(i => i.matchedRule.group).filter(i => i != null);
+
+            groups = (groups.length) ? [...new Set(groups)] : Object.keys(this.params.hooks); // If there are no groups defined, send to all of them
+
+            for (let group of groups) {
+                if (this.params.hooks[group]) {
+                    this._sendHTTPMessage(this.params.hooks[group], channel, content);
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
A report that allows generic HTTP calls.
It can be used for integrating various messaging platforms (including #81).