### PR TITLE
Example template for http is not json

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -194,7 +194,7 @@ reports:
 #      templates: # See here how to write a template https://github.com/nttgin/BGPalerter/blob/master/docs/context.md
 #        default: '{"text": "${summary}"}'
 #      headers:
-#      isTemplateJSON: true
+#      isTemplateJSON: false
 #      showPaths: 0 # Amount of AS_PATHs to report in the alert
 #      hooks:
 #        default: _YOUR_WEBHOOK_URL_


### PR DESCRIPTION
* Set `isTemplateJSON` to false otherwise would trigger an error "as-is"

This is just for easy to use defaults.

The error triggered would otherwise be:
```
SyntaxError: Unexpected token
 in JSON at position 192
    at JSON.parse (<anonymous>)
    at ReportHTTP._sendHTTPMessage (/snapshot/BGPalerter/build/src/reports/reportHTTP.js:71:50)
    at ReportHTTP.report (/snapshot/BGPalerter/build/src/reports/reportHTTP.js:97:21)
    at /snapshot/BGPalerter/build/src/reports/report.js:184:22
    at /snapshot/BGPalerter/build/src/utils/pubSub.js:45:13
    at new Promise (<anonymous>)
    at _loop (/snapshot/BGPalerter/build/src/utils/pubSub.js:44:11)
    at PubSub.publish (/snapshot/BGPalerter/build/src/utils/pubSub.js:51:11)
    at MonitorNewPrefix._publishOnChannel (/snapshot/BGPalerter/build/src/monitors/monitor.js:206:18)
    at MonitorNewPrefix._publishGroupId (/snapshot/BGPalerter/build/src/monitors/monitor.js:188:13)
```

(does not appear in errors log but out stderr, not sure if expected)