### PR TITLE
Adding Cloudflare to the list of RPKI VRP providers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,7 +309,7 @@ Parameters for this monitor module:
 |preCacheROAs| When this parameter is set to true (default), BGPalerter will download Validated ROA Payloads (VRPs) lists locally instead of using online validation. More info [here](https://github.com/massimocandela/rpki-validator).|
 |refreshVrpListMinutes| If `preCacheROAs` is set to true, this parameter allows to specify a refresh time for the VRPs lists (it has to be > 15 minutes) |
 |thresholdMinPeers| Minimum number of peers that need to see the BGP update before to trigger an alert. |
-|vrpProvider| A string indicating the provider of the VRPs list. Possible options are: `ntt` (default), `ripe`, `external`. Use external only if you wish to specify a file with `vrpFile`. More info [here](https://github.com/massimocandela/rpki-validator#options).|
+|vrpProvider| A string indicating the provider of the VRPs list. Possible options are: `ntt` (default), `ripe`, `cloudflare`, `external`. Use external only if you wish to specify a file with `vrpFile`. More info [here](https://github.com/massimocandela/rpki-validator#options).|
 |vrpFile| A JSON file with an array of VRPs. See example below.|
 |maxDataSamples| Maximum number of collected BGP messages for each alert which doesn't reach yet the `thresholdMinPeers`. Default to 1000. As soon as the `thresholdMinPeers` is reached, the collected BGP messages are flushed, independently from the value of `maxDataSamples`.|
 

--- a/src/monitors/monitorRPKI.js
+++ b/src/monitors/monitorRPKI.js
@@ -7,7 +7,7 @@ export default class MonitorRPKI extends Monitor {
     constructor(name, channel, params, env){
         super(name, channel, params, env);
 
-        this.providers = [ "ntt", "ripe", "external"]; // First provider is the default one
+        this.providers = [ "ntt", "ripe", "cloudflare", "external" ]; // First provider is the default one
 
         this.refreshVrpListMinutes = this.params.refreshVrpListMinutes || 15;
         this.preCacheROAs = this.params.preCacheROAs !== false;


### PR DESCRIPTION
It seems like ``rpki-validator`` providers a connector for the
Cloudflare VRP, I believe we could add it to the list of possible VRP
providers. However, if this wasn't included due to a design choice, I'm
happy to close this PR. :smiley: 