### PR TITLE
Allow Configurable Timezone at Runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:12-alpine as build
 WORKDIR /opt/bgpalerter
 COPY . .
 
+# Makes the final image respect /etc/timezone configuration
+RUN apk add --no-cache tzdata
+
 RUN npm install
 
 ENTRYPOINT ["npm"]


### PR DESCRIPTION
This is needed to make the container respect /etc/timezone or $TZ config which may be set at runtime. Otherwise, the container userland always assumes GMT/UTC.