### PR TITLE
report software updates everywhere unless explicitly configured

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -281,8 +281,6 @@ if (!config.reports.some((report) => report.channels.includes("software-update")
   })
 }
 
-console.dir(config.reports)
-
 config.connectors = config.connectors || [];
 
 config.connectors.push({

--- a/src/env.js
+++ b/src/env.js
@@ -269,11 +269,20 @@ config.reports = (config.reports || [])
 
         return {
             class: require("./reports/" + item.file).default,
-            channels: [...item.channels, "software-update"],
+            channels: [...item.channels],
             params: item.params
         };
 
     });
+
+if (!config.reports.some((report) => report.channels.includes("software-update"))) {
+  config.reports.forEach((report) => {
+    report.channels.push("software-update");
+  })
+}
+
+console.dir(config.reports)
+
 config.connectors = config.connectors || [];
 
 config.connectors.push({


### PR DESCRIPTION
**What's the problem?**

BGP alerter connects the software updates channel to all reports by default.  This could be problem if a report is designed to be disruptive (e.g. if the report generates a page).

**How does this solve it?**

Maintains the existing behaviour if no reporters listen on `software-update`.  Where a reporter is explicitly listening on this channel, we'll no longer automatically add this channel to all reporters.