### PR TITLE
fix slack report colors

### DIFF
--- a/src/reports/reportSlack.js
+++ b/src/reports/reportSlack.js
@@ -50,7 +50,7 @@ export default class ReportSlack extends ReportHTTP {
             });
         };
 
-        for (let channel in channels) {
+        for (let channel of channels) {
             templates[channel] = getTemplateItem(colors[channel] || defaultColor);
         }
         templates["default"] = getTemplateItem(defaultColor);


### PR DESCRIPTION
Slack colours seem to have been broken since f9e582bca3c40727ee7fb86cb6f6c3da26e5fab2 and always return the default colour (blue) for all channels.

The example config shows channels is a list (array in js?)
but colors is a dict.

```
  - file: reportSlack
    channels:                      <- List []
      - hijack
      - newprefix
      - visibility
      - path
      - misconfiguration
      - rpki
    params:
      showPaths: 0 # Amount of AS_PATHs to report in the alert
      colors:                       <- Dict {}
        hijack: '#d60b1c' 
        newprefix: '#fa9548'
        visibility: '#fad648'
        path: '#42cbf5'
        rpki: '#d892f0'
      hooks:
        default: _YOUR_SLACK_WEBHOOK_URL_
        noc: _YOUR_SLACK_WEBHOOK_URL_
```

https://github.com/nttgin/BGPalerter/blob/8b447d698d70291678f357c29694f99342cfe042/src/reports/reportSlack.js#L53
this line sets `channel` as the **index** of the list item, rather than the **value** of the list item.

after the for loop, the template ends up looking something like this
```
{
"0":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}",
"1":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}",
"2":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}",
"3":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}",
"4":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}",
"5":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}",
"6":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}",
"default":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}"
}
```
where the keys in the template are integers, rather than the channel names.
this results in the channel never being found in the template and default being used.

&nbsp;&nbsp;

this simple change of `in` to `of` will set `channel` as the **value** in the list.

```
{
"hijack":"{\"attachments\":[{\"color\":\"#d60b1c\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}","
newprefix":"{\"attachments\":[{\"color\":\"#fa9548\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}","
visibility":"{\"attachments\":[{\"color\":\"#fad648\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}","
path":"{\"attachments\":[{\"color\":\"#42cbf5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}","
rpki":"{\"attachments\":[{\"color\":\"#d892f0\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}","
default":"{\"attachments\":[{\"color\":\"#4287f5\",\"title\":\"${channel}\",\"text\":\"${summary}\"}]}"
}
```

i have tested this with the `-t` test parameter and the results are as follows:

![reportSlackColors](https://user-images.githubusercontent.com/84198105/128605392-b3551260-28ed-4924-a4cd-977670272ebc.png)

(note the correct colour being displayed for a hijack #d60b1c (red) vs #4287f5 (blue)).
