### PR TITLE
Update name for 12128489 Canada Inc

### DIFF
--- a/docs/friends.md
+++ b/docs/friends.md
@@ -23,7 +23,7 @@ Please, let me know so I can add your company name here.
 * Artfiles GmbH (AS8893)
 * Namex IXP (AS24796)
 * Zero Attack Vector LLC (AS212996 & AS398549)
-* 12128489 Canada Inc dba Accuris Hosting (AS212934)
+* Accuris Technologies Ltd. (AS212934)
 * Brennercom S.p.A. (AS20811)
 * Solcon Internetdiensten B.V. (AS12414)
 * Webair (AS27257)


### PR DESCRIPTION
12128489 Canada Inc has officially changed it's legal and operating name to Accuris Technologies Ltd. This commit has been made to update the friends.md file with the updated name, previous listed under "12128489 Canada Inc dba Accuris Hosting".