### PR TITLE
Added: Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- trivial container for BGPalerter
-FROM node:14-alpine as build
+FROM node:14.20.0-alpine as build
 
 WORKDIR /opt/bgpalerter
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 # Makes the final image respect /etc/timezone configuration
 RUN apk add --no-cache tzdata
 
-RUN npm ci
+RUN npm ci --no-audit --prefer-offline
 
 ENTRYPOINT ["npm"]
 CMD ["run", "serve"]


### PR DESCRIPTION
I introduced the flags --no-audit and --prefer-offline. We don't need an audit for the packages we use, because we already use Dependabot to alert us on repository level. With --prefer-offline we try to use the already downloaded packages.