### PR TITLE
debian: dont strip packages.json also inject shebang

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+node-bgpalerter (1.31.1-1) unstable; urgency=medium
+
+    * Don't strip packages.json
+    * inject a shebang top the bin script
+
+ -- John Bond <jbond@wikimedia.org>  Fri, 06 Jan 2023 15:39:06 +0100
+
 node-bgpalerter (1.29.0-1) unstable; urgency=medium
 
   * Initial release

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ override_dh_auto_install:
 	npm install --prefix "${CURDIR}/debian/node-bgpalerter/usr" -g ${CURDIR}/build/bgpalerter-*.tgz
 	find "${CURDIR}/debian/node-bgpalerter/usr" \
 		\( -name .npmignore -o -name .eslintrc -o -name .eslintrc.js -o -name \*.md -o -name LICENSE \
-		-o -name LICENSE-jsbn -o -name package.json -o -name .gitmodules -o -name .gitattributes \) \
+		-o -name LICENSE-jsbn -o -name .gitmodules -o -name .gitattributes \) \
 		-type f -delete
 	find "${CURDIR}/debian/node-bgpalerter/usr/lib/node_modules/bgpalerter/node_modules" \
 		\( -name examples -name .bin -o -name bin \) -type d -exec rm -rf {} +
@@ -27,6 +27,7 @@ override_dh_link:
 
 override_dh_fixperms:
 	dh_fixperms
+	sed -i '1i #!/usr/bin/node' "${CURDIR}/debian/node-bgpalerter/usr/lib/node_modules/bgpalerter/index.js"
 	chmod +x "${CURDIR}/debian/node-bgpalerter/usr/lib/node_modules/bgpalerter/index.js"
 
 override_dh_auto_clean:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bgpalerter",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bgpalerter",
-      "version": "1.31.0",
+      "version": "1.31.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sentry/node": "^7.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bgpalerter",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "BGP and RPKI monitoring tool. Pre-configured for real-time detection of visibility loss, RPKI invalid announcements, hijacks, ROA misconfiguration, and more.",
   "author": {
     "name": "Massimo Candela",


### PR DESCRIPTION
Hi i noticed a couple of issues with the current Debian packaging, in that i was stripping packages.json resulting in node not being able to find any dependencies and also the resulting bgptalert bin had no shebang.  This PR should fix both issues