### PR TITLE
add reportMatrix module

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -282,7 +282,7 @@ reports:
 #      accessToken: _ACCESS_TOKEN_ 
 #      roomIds:
 #        default: "_ROOM_ID_"
-#		 noc: "_ROOM_ID_"
+#        noc: "_ROOM_ID_"
 
 
 ############################

--- a/config.yml.example
+++ b/config.yml.example
@@ -267,6 +267,24 @@ reports:
 #    params:
 #      maxAlertsAmount: 25
 
+#  - file: reportMatrix
+#    channels:
+#      - hijack
+#      - newprefix
+#      - visibility
+#      - path
+#      - misconfiguration
+#      - rpki
+#      - roa
+#    params:
+#      showPaths: 0 # Amount of AS_PATHs to report in the alert
+#      homeserverUrl: https://matrix.org
+#      accessToken: _ACCESS_TOKEN_ 
+#      roomIds:
+#        default: "_ROOM_ID_"
+#		 noc: "_ROOM_ID_"
+
+
 ############################
 # Notification settings:
 # - notificationIntervalSeconds

--- a/docs/friends.md
+++ b/docs/friends.md
@@ -56,3 +56,5 @@ Please, let me know so I can add your company name here.
 * Rechenzentrum Haßfurt GmbH (AS44973)
 * obe.net (AS3399)
 * IT-Total (AS8769)
+* Speakup (AS49627)
+* Nick Bouwhuis (AS202585)

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -20,6 +20,7 @@ This will generate fake alerts. [Read more here](installation.md#bgpalerter-para
 - [reportHTTP](reports.md#reportHTTP)
 - [reportTelegram](reports.md#reportTelegram)
 - [reportPullAPI](reports.md#reportPullAPI)
+- [reportMatrix](reports.md#reportMatrix)
 
 ## reportFile
 
@@ -172,10 +173,26 @@ This report module creates a REST API reachable at `http://host:port/alerts/`. T
 
 The REST API uses the generic `rest` configuration in `config.yml`. Read [here](configuration.md) or see `config.yml.example` for more information.
 
-
 Parameters for this report module:
 
 |Parameter| Description| 
 |---|---|
 |maxAlertsAmount| The maximum amount of alerts the API will return. By default set to 100. Don't exagerate with the number, the greater this value is the more memory BGPalerter will use. |
 |noProxy| If there is a global proxy configuration (see [here](http-proxy.md)), this parameter if set to true allows the single module to bypass the proxy. |
+
+## reportMatrix
+
+This report module sends alerts directly to a specific Matrix room.
+To send alert to Matrix you need an access token and a room ID.
+
+Parameters for this report module:
+
+|Parameter| Description| 
+|---|---|
+|showPaths| Amount of AS_PATHs to report in the alert (0 to disable). |
+|homeserverUrl:| URL of your Matrix homeserver (for example: `https://matrix.org` |
+|noProxy| If there is a global proxy configuration (see [here](http-proxy.md)), this parameter if set to true allows the single module to bypass the proxy. |
+|roomIds| A dictionary containing chat IDs grouped by user group (key: group, value: room ID).| 
+|roomIds.default| The room ID of the default room.| 
+
+

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -200,4 +200,4 @@ Parameters for this report module:
 |roomIds| A dictionary containing chat IDs grouped by user group (key: group, value: room ID). |
 |roomIds.default| The room ID of the default room.| 
 
-
+Thanks to [@nickbouwhuis](https://github.com/nttgin/BGPalerter/pull/1043).

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -185,14 +185,19 @@ Parameters for this report module:
 This report module sends alerts directly to a specific Matrix room.
 To send alert to Matrix you need an access token and a room ID.
 
+You can find your access token in the Element client by going to All Settings > Help & About > Advanced. Read more about access tokens [here](https://spec.matrix.org/v1.6/client-server-api/#using-access-tokens).
+
+You can find the room ID in the Element client by going to Room info > Room Settings > Advanced. Read more about Room ID [here](https://spec.matrix.org/latest/#room-structure).
+
 Parameters for this report module:
 
 |Parameter| Description| 
 |---|---|
 |showPaths| Amount of AS_PATHs to report in the alert (0 to disable). |
-|homeserverUrl:| URL of your Matrix homeserver (for example: `https://matrix.org` |
+|homeserverUrl| URL of your Matrix homeserver (for example: `https://matrix.org`. |
 |noProxy| If there is a global proxy configuration (see [here](http-proxy.md)), this parameter if set to true allows the single module to bypass the proxy. |
-|roomIds| A dictionary containing chat IDs grouped by user group (key: group, value: room ID).| 
+|accessToken| The access token for authentication yourself to the Matrix API. |
+|roomIds| A dictionary containing chat IDs grouped by user group (key: group, value: room ID). |
 |roomIds.default| The room ID of the default room.| 
 
 

--- a/src/reports/reportMatrix.js
+++ b/src/reports/reportMatrix.js
@@ -31,12 +31,13 @@
  */
 
 import ReportHTTP from "./reportHTTP";
+import { v4 as uuidv4 } from 'uuid';
 
 export default class reportMatrix extends ReportHTTP {
 
     constructor(channels, params, env) {
         const hooks = {};
-        const transactionId = Math.random().toString(36).substring(2, 15);
+        const transactionId = uuidv4();
 
         for (let userGroup in params.roomIds) {
             hooks[userGroup] = params.homeserverUrl + "/_matrix/client/v3/rooms/" + encodeURIComponent(params.roomIds[userGroup]) + "/send/m.room.message/" + transactionId;

--- a/src/reports/reportMatrix.js
+++ b/src/reports/reportMatrix.js
@@ -1,0 +1,87 @@
+/*
+ * 	BSD 3-Clause License
+ *
+ * Copyright (c) 2019, NTT Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ *  Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import ReportHTTP from "./reportHTTP";
+
+export default class reportMatrix extends ReportHTTP {
+
+    constructor(channels, params, env) {
+        const hooks = {};
+        const transactionId = Math.random().toString(36).substring(2, 15);
+
+        for (let userGroup in params.roomIds) {
+            hooks[userGroup] = params.homeserverUrl + "/_matrix/client/v3/rooms/" + encodeURIComponent(params.roomIds[userGroup]) + "/send/m.room.message/" + transactionId;
+        }
+        hooks["default"] = params.homeserverUrl + "/_matrix/client/v3/rooms/" + encodeURIComponent(params.roomIds["default"]) + "/send/m.room.message/" + transactionId;
+
+
+        const matrixParams = {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": "Bearer " + params.accessToken
+            },
+            isTemplateJSON: true,
+            showPaths: params.showPaths,
+            hooks: hooks,
+            name: "reportMatrix",
+            method: "put",
+            templates: {}
+        };
+
+        super(channels, matrixParams, env);
+        this.roomIds = params.roomIds;
+
+        if (!params.homeserverUrl || !params.accessToken) {
+            this.logger.log({
+                level: 'error',
+                message: `${this.name} reporting is not enabled: homeserverUrl and accessToken are required`
+            });
+            this.enabled = false;
+        }
+
+        if (!params.roomIds || !params.roomIds["default"]) {
+            this.logger.log({
+                level: 'error',
+                message: `${this.name} reporting is not enabled: no default room id provided`
+            });
+            this.enabled = false;
+        }
+    };
+
+    getTemplate = (group, channel, content) => {
+        return JSON.stringify({
+            "msgtype": "m.text",
+            "body": "${summary}${markDownUrl}",
+        });
+    };
+}
+


### PR DESCRIPTION
Added the reportMatrix module and documentation for it. 

Matrix requires messages to include a `txId` (as can be read in the Matrix documentation [here](https://spec.matrix.org/v1.5/client-server-api/#sending-events-to-a-room)) and thus the reportHTTP module cannot be used.