### PR TITLE
Add action to auto build debian package

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-debs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jtdor/build-deb-action@v1
+        env:
+          DEB_BUILD_OPTIONS: noautodbgsym
+        with:
+          buildpackage-opts: --build=binary --no-sign
+          extra-build-deps: git
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            LICENSE
+            debian/artifacts/*.deb


### PR DESCRIPTION
This adds an action to automatically build a debian package and add it to the release tag page every time a new tag starting `v*` is created.  see [here](https://github.com/b4ldr/BGPalerter/releases/tag/v42.0.0) for an example

The action i used also parses the commits and adds them to the release to form a changelog.  personally i think this is useful but im sure there will be other actions that just attach the files if its not desired.

closes #1111