### PR TITLE
Update documentation to reflect the current telegram botUrl format and validate it in the report file

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -162,7 +162,7 @@ Parameters for this report module:
 |Parameter| Description| 
 |---|---|
 |showPaths| Amount of AS_PATHs to report in the alert (0 to disable). |
-|botUrl| The Telegram bot URL. Usually `https://api.telegram.org/bot_BOT_ID_/` where `_BOT_ID_` is your both ID. |
+|botUrl| The Telegram bot URL. `https://api.telegram.org/bot_BOT_ID_/sendMessage` where `_BOT_ID_` is your bot ID. |
 |noProxy| If there is a global proxy configuration (see [here](http-proxy.md)), this parameter if set to true allows the single module to bypass the proxy. |
 |chatIds| A dictionary containing chat IDs grouped by user group (key: group, value: chat ID).| 
 |chatIds.default| The chat ID of the default user group.| 

--- a/src/reports/reportTelegram.js
+++ b/src/reports/reportTelegram.js
@@ -54,10 +54,10 @@ export default class reportTelegram extends ReportHTTP {
         super(channels, telegramParams, env);
         this.chatIds = params.chatIds;
 
-        if (!params.botUrl) {
+        if (!params.botUrl || !(params.botUrl.startsWith("https://api.telegram.org/bot") && params.botUrl.endsWith("/sendMessage"))) {
             this.logger.log({
                 level: 'error',
-                message: `${this.name} is not enabled: no botUrl provided`
+                message: `${this.name} is not enabled: invalid botUrl provided`
             });
             this.enabled = false;
         }


### PR DESCRIPTION
Currently the documentation states a wrong format for the telegram bot url which caused me quite a lot of frustration.
This PR fixed the above and validates it in the report file, providing an error if the format does not (loosely) match.