### PR TITLE
Logging to console

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -332,7 +332,14 @@ logging:
   maxFileSizeMB: 15
   compressOnRotation: false
   useUTC: true
-  
+
+# Alternative configuration for logging to console (stdout)
+#logging:
+#  console: true
+#  timestamp: false
+#  useUTC: true
+
+
 checkForUpdatesAtBoot: true
 generatePrefixListEveryDays: 0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,11 +9,13 @@ The following are common parameters which it is possible to specify in the confi
 |notificationIntervalSeconds|Defines the amount of seconds after which an alert can be repeated. An alert is repeated only if the event that triggered it is not yet solved. Please, don't set this value to Infinity, use instead alertOnlyOnce. | An integer | 1800 | Yes |
 |monitoredPrefixesFiles| The [list](prefixes.md#array) of files containing the prefixes to monitor. See [here](prefixes.md#prefixes) for more informations. | A list of strings (valid .yml files) | -prefixes.yml | Yes |
 |logging| A dictionary of parameters containing the configuration for the file logging. | || Yes|
-|logging.directory| The directory where the log files will be generated. The directory will be created if not existent. | A string | logs | Yes |
-|logging.logRotatePattern| A pattern with date placeholders indicating the name of the file. This pattern will also indicate when a log file is rotated. | A string with date placeholders (YYYY, MM, DD, ss, hh) | YYYY-MM-DD | Yes |
-|logging.compressOnRotation| Indicates if when a file gets rotates it has to be compressed or not. | A boolean | true | Yes |
-|logging.maxFileSizeMB| Indicates the maximum file size in MB allowed before to be rotated. This allows to rotate files when logRotatePattern still the same but the file is too big | An integer | 15 | Yes |
-|logging.maxRetainedFiles| Indicates the maximum amount of log files retained. When this threshold is passed, files are deleted. | An integer | 10 | Yes |
+|logging.directory| The directory where the log files will be generated. The directory will be created if not existent. | A string | logs | No |
+|logging.logRotatePattern| A pattern with date placeholders indicating the name of the file. This pattern will also indicate when a log file is rotated. | A string with date placeholders (YYYY, MM, DD, ss, hh) | YYYY-MM-DD | Yes if directory |
+|logging.compressOnRotation| Indicates if when a file gets rotates it has to be compressed or not. | A boolean | true | Yes if directory |
+|logging.maxFileSizeMB| Indicates the maximum file size in MB allowed before to be rotated. This allows to rotate files when logRotatePattern still the same but the file is too big | An integer | 15 | Yes if directory |
+|logging.maxRetainedFiles| Indicates the maximum amount of log files retained. When this threshold is passed, files are deleted. | An integer | 10 | Yes if directory |
+|logging.console| Whether to log to console instead of files; directory must be unset for this to take effect. | A boolean | true | No |
+|logging.timestamp| Whether to add a timestamp when logging to console. | A boolean | true | No |
 |logging.useUTC| If set to true, logs will be reported in UTC time. Is set to false or missing, the timezone of the machine will be used. This parameter affects only the timestamp reported at the beginning of each log entry, it doesn't affect the time reported in the data/alerts which is always in UTC.  | A boolean | true | No |
 |checkForUpdatesAtBoot| Indicates if at each booth the application should check for updates. If an update is available, a notification will be sent to the default group. If you restart the process often (e.g., debugging, experimenting etc.) set this to false to avoid notifications. Anyway, BGPalerter checks for updates every 10 days.| A boolean | true | Yes |
 |processMonitors| A list of modules allowing various ways to check for the status of BGPalerter (e.g., API, heartbeat). See [here](process-monitors.md) for more information. | | | No | 

--- a/src/env.js
+++ b/src/env.js
@@ -33,6 +33,7 @@
 import fs from "fs";
 import PubSub from "./utils/pubSub";
 import FileLogger from "fast-file-logger";
+import moment from "moment";
 import {version} from "../package.json";
 import Storage from "./utils/storages/storageFile";
 import RpkiUtils from "./utils/rpkiUtils";
@@ -83,54 +84,81 @@ if (!config.configVersion || config.configVersion < Config.configVersion) {
     console.log("Your config.yml file is old. It works, but it may not support all the new features. Update your config file or generate a new one (e.g., rename the file into config.yml.bak, run BGPalerter and proceed with the auto configuration, apply to the new config.yml the personalizations you did in config.yml.bak.");
 }
 
-const loggingDirectory = config.volume + config.logging.directory;
-
-try {
-    if (!fs.existsSync(loggingDirectory)) {
-        fs.mkdirSync(loggingDirectory, {recursive: true});
-    }
-} catch (error) {
-    console.log(error);
+if (config.logging.directory && config.logging.console) {
+    console.log("Cannot enable both file logging and console logging at the same time. File logging takes precedence.");
 }
 
-const errorTransport = new FileLogger({
-    logRotatePattern: config.logging.logRotatePattern,
-    filename: "error-%DATE%.log",
-    symLink: "error.log",
-    directory: loggingDirectory,
-    maxRetainedFiles: config.logging.maxRetainedFiles,
-    maxFileSizeMB: config.logging.maxFileSizeMB,
-    compressOnRotation: config.logging.compressOnRotation,
-    label: config.environment,
-    useUTC: !!config.logging.useUTC,
-    format: ({data, timestamp}) => `${timestamp} ${data.level}: ${data.message}`
-});
+if (config.logging.directory) {
+    const loggingDirectory = config.volume + config.logging.directory;
 
-const verboseTransport = new FileLogger({
-    logRotatePattern: config.logging.logRotatePattern,
-    filename: "reports-%DATE%.log",
-    symLink: "reports.log",
-    directory: loggingDirectory,
-    maxRetainedFiles: config.logging.maxRetainedFiles,
-    maxFileSizeMB: config.logging.maxFileSizeMB,
-    compressOnRotation: config.logging.compressOnRotation,
-    label: config.environment,
-    useUTC: !!config.logging.useUTC,
-    format: ({data, timestamp}) => `${timestamp} ${data.level}: ${data.message}`
-});
-
-const loggerTransports = {
-    verbose: verboseTransport,
-    error: errorTransport,
-    info: errorTransport
-};
-
-const wlogger = {
-    log:
-        function (data) {
-            return loggerTransports[data.level].log(data);
+    try {
+        if (!fs.existsSync(loggingDirectory)) {
+            fs.mkdirSync(loggingDirectory, {recursive: true});
         }
-};
+    } catch (error) {
+        console.log(error);
+    }
+
+    const errorTransport = new FileLogger({
+        logRotatePattern: config.logging.logRotatePattern,
+        filename: "error-%DATE%.log",
+        symLink: "error.log",
+        directory: loggingDirectory,
+        maxRetainedFiles: config.logging.maxRetainedFiles,
+        maxFileSizeMB: config.logging.maxFileSizeMB,
+        compressOnRotation: config.logging.compressOnRotation,
+        label: config.environment,
+        useUTC: !!config.logging.useUTC,
+        format: ({data, timestamp}) => `${timestamp} ${data.level}: ${data.message}`
+    });
+
+    const verboseTransport = new FileLogger({
+        logRotatePattern: config.logging.logRotatePattern,
+        filename: "reports-%DATE%.log",
+        symLink: "reports.log",
+        directory: loggingDirectory,
+        maxRetainedFiles: config.logging.maxRetainedFiles,
+        maxFileSizeMB: config.logging.maxFileSizeMB,
+        compressOnRotation: config.logging.compressOnRotation,
+        label: config.environment,
+        useUTC: !!config.logging.useUTC,
+        format: ({data, timestamp}) => `${timestamp} ${data.level}: ${data.message}`
+    });
+
+    const loggerTransports = {
+        verbose: verboseTransport,
+        error: errorTransport,
+        info: errorTransport
+    };
+
+    var wlogger = {
+        log:
+            function (data) {
+                return loggerTransports[data.level].log(data);
+            }
+    };
+} else if (config.logging.console) {
+    const format = (!!config.logging.timestamp) ?
+            (data) => {
+                const now = (!!config.logging.useUTC) ? moment.utc() : moment();
+                const timestamp = now.format('YYYY-MM-DDTHH:mm:ssZ');
+                return `${timestamp} ${data.level}: ${data.message}`;
+            } :
+            (data) => {
+                return `${data.level}: ${data.message}`;
+            };
+    var wlogger = {
+        log:
+            function (data) {
+                console.log(format(data))
+            }
+    };
+} else {
+    var wlogger = {
+        log:
+            function (data) {}
+    };
+}
 
 config.monitors = (config.monitors || []);
 config.monitors.push({


### PR DESCRIPTION
Add support for alternative logging configuration `console: true` for logging to stdout through `console.log`, instead of logging to files.  This is useful in modern deployment scenarios where logs are generally managed outside of the application.

If neither directory nor console are configured, logging is disabled.  The default configuration is unchanged, this change is fully backwards-compatible.

You may want to change the way this is configured, or introduce something like pine to replace the custom logging code.  All I really need is some way to redirect logs to either stdout or stderr, hence the minimal solution.