### PR TITLE
Fix exit code for generate-prefixes subcommand

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,10 @@ switch (params._[0]) {
             .then(content => {
                 fs.writeFileSync(params.o, yaml.dump(content));
                 process.exit(0);
+            })
+            .catch((e) => {
+                console.log(`Something went wrong ${e}`);
+                process.exit(1)
             });
 
         break;

--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ switch (params._[0]) {
             })
             .catch((e) => {
                 console.log(`Something went wrong ${e}`);
-                process.exit(1)
+                process.exit(1);
             });
 
         break;

--- a/src/generatePrefixesList.js
+++ b/src/generatePrefixesList.js
@@ -415,9 +415,6 @@ module.exports = function generatePrefixes(inputParameters) {
                         }
                     }))
                 : generateList;
-        })
-        .catch((e) => {
-            logger(`Something went wrong ${e}`);
         });
 
 };


### PR DESCRIPTION
Hello Massimo @massimocandela , 

This fix allows to ensure that prefixes are reliably generated and thus shell is exited with non-zero code. 

Prefixes can be generated on start and this makes sense to fail fast at step where problem appeared.

In input.js this may be breaking change, e.g. catch flow will work and print exception, but overall this will be proper behaviour.

Before:

```bash
$ npm run generate-prefixes -- --a 1111--o /volume/bgpalerter/prefixes.yml

> bgpalerter@2.0.1 generate-prefixes
> babel-node index.js generate --a 1111--o /volume/bgpalerter/prefixes.yml

Getting announced prefixes of AS1111
It was not possible to retrieve the announced prefixes of 1111. TypeError: fetch failed
Total prefixes detected: 0
Something went wrong TypeError: fetch failed
$ echo $?
0
```

After:

```bash
$ echo $?
1
```