### PR TITLE
Fix hostname in syslog messages

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -88,6 +88,7 @@ Parameters for this report module:
 |showPaths| Amount of AS_PATHs to report in the alert (0 to disable). | 
 |host| Host of the Syslog server (e.g., localhost).| 
 |port| Port of the Syslog server  (e.g., 514).| 
+|syslogHostname| Hostname to place in the header of each syslog message emitted. This is meant to identify the host that emitted the message, not the syslog server that received it. Defaults to OS hostname if not set.| 
 |transport| The transport protocol to use. Two options: `udp` or `tcp`| 
 |templates| A dictionary containing string templates for each BGPalerter channels. If a channel doesn't have a template defined, the `default` template will be used (see `config.yml.example` for more details). |
 

--- a/src/reports/reportSyslog.js
+++ b/src/reports/reportSyslog.js
@@ -32,6 +32,7 @@
 
 import Report from "./report";
 import syslog from "syslog-client";
+import os from "os";
 
 export default class ReportSyslog extends Report {
 
@@ -42,7 +43,7 @@ export default class ReportSyslog extends Report {
         this.connecting = null;
         this.host = params.host;
         this.options = {
-            syslogHostname: params.host,
+            syslogHostname: params.syslogHostname || os.hostname(),
             transport: (params.transport === "tcp") ? syslog.Transport.Tcp : syslog.Transport.Udp,
             port: params.port
         };


### PR DESCRIPTION
BGPalerter currently reuses the `host` config field, i.e. the syslog server it submits to, as the hostname field in syslog messages. However, the hostname field in syslog messages is supposed to be the hostname of the host that *originates* the log entry, not the syslog server that the messages are submitted to.  This is not just a theoretical problem; the hostname field is of key importance in centralized logging setups where the hostname field is used to tell log sources apart when syslog is involved.

The fix introduces a new config option `syslogHostname` to override the hostname to use, and falls back to `os.hostname()`, which matches the default of `syslog-client` and is generally a sensible default.

This issue prevented me from using the syslog report module in a real-world BGPalerter deployment.

### Testing

Tested against 2.0.1 `main` because `dev` currently does not compile cleanly.

Submitted logs before fix:

```
<134>Apr  4 21:42:49 127.0.0.1 ++BGPalerter-5-monitor-passthrough: type:announcement timestamp:1775331769543 prefix:165.254.255.0/25 peer:124.0.0.2 path:[1,2,3,[4,15562]] nextHop:124.0.0.2 aggregator:null|0.0.0.0/0|test|1234|165.254.255.0/25|AS4, and AS15562|2026-04-04 19:42:49|2026-04-04 19:42:49|1
<134>Apr  4 21:42:49 127.0.0.1 ++BGPalerter-5-monitor-passthrough: type:announcement timestamp:1775331769543 prefix:2a00:5884:ffff::/48 peer:124.0.0.3 path:[1,2,3,208585] nextHop:124.0.0.3 aggregator:null|0.0.0.0/0|test|1234|2a00:5884:ffff::/48|AS208585|2026-04-04 19:42:49|2026-04-04 19:42:49|1
```

Submitted logs with fix, `syslogHostname` not set:

```
<134>Apr  4 21:41:10 redacted.example.net ++BGPalerter-5-monitor-passthrough: type:announcement timestamp:1775331670866 prefix:175.254.205.0/25 peer:124.0.0.3 path:[1,2,3,4321] nextHop:124.0.0.3 aggregator:null|0.0.0.0/0|test|1234|175.254.205.0/25|AS4321|2026-04-04 19:41:10|2026-04-04 19:41:10|1
<134>Apr  4 21:41:10 redacted.example.net ++BGPalerter-5-monitor-passthrough: type:announcement timestamp:1775331670866 prefix:170.254.205.0/25 peer:124.0.0.3 path:[1,2,3,4321] nextHop:124.0.0.3 aggregator:null|0.0.0.0/0|test|1234|170.254.205.0/25|AS4321|2026-04-04 19:41:10|2026-04-04 19:41:10|1
```

Submitted logs with fix, `syslogHostname` set to `redacted.example.com`:

```
<134>Apr  4 21:44:58 redacted.example.com ++BGPalerter-5-monitor-passthrough: type:announcement timestamp:1775331898292 prefix:175.254.205.0/25 peer:124.0.0.3 path:[1,2,3,4321] nextHop:124.0.0.3 aggregator:null|0.0.0.0/0|test|1234|175.254.205.0/25|AS4321|2026-04-04 19:44:58|2026-04-04 19:44:58|1
<134>Apr  4 21:44:58 redacted.example.com ++BGPalerter-5-monitor-passthrough: type:announcement timestamp:1775331898292 prefix:170.254.205.0/25 peer:124.0.0.3 path:[1,2,3,4321] nextHop:124.0.0.3 aggregator:null|0.0.0.0/0|test|1234|170.254.205.0/25|AS4321|2026-04-04 19:44:58|2026-04-04 19:44:58|1
```