### PR TITLE
feat(telegram): add support for topics in groups

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -268,6 +268,9 @@ reports:
 #      chatIds:
 #        default: _CHAT_ID_
 #        noc: _CHAT_ID_
+#      messageThreadIds:
+#        default: _OPTIONAL_THREAD_ID_
+#        noc: _OPTIONAL_THREAD_ID_
 
 #  - file: reportPullAPI
 #    channels:

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -142,7 +142,7 @@ Parameters for this report module:
 
 ## reportTelegram
 
-This report module sends alerts directly to specified Telegram users, groups, or channels.
+This report module sends alerts directly to specified Telegram users, groups, or channels. It also supports routing messages to specific topics within Forum Supergroups.
 To send alert to Telegram you need to create a bot.
 
 To create a bot:
@@ -152,6 +152,7 @@ To create a bot:
 4. Open the chat (channel, group, user) where you want to send the alerts.
 5. Write something in the chat (from whatever user).
 6. Visit `https://api.telegram.org/bot_BOT_ID_/getUpdates` (replace `_BOT_ID_` with your bot ID) from your browser and take note of the chat ID returned in the answer. In case of multiple chat IDs, use the one with the same text you sent at the previous point.
+7. *(Optional)* If using Forum Topics, navigate to the specific topic thread in your group chat. Copy the link to any message in that topic. The link will look like `https://t.me/c/123456789/42/50`. The middle number (`42`) is your `message_thread_id`.
 
 Parameters for this report module:
 
@@ -161,6 +162,8 @@ Parameters for this report module:
 |botUrl| The Telegram bot URL. Usually, `https://api.telegram.org/bot_BOT_ID_/sendMessage` where `_BOT_ID_` is your both ID.                               |
 |chatIds| A dictionary containing chat IDs grouped by user group (key: group, value: chat ID).                                                              | 
 |chatIds.default| The chat ID of the default user group.                                                                                                            | 
+|messageThreadIds| *(Optional)* A dictionary containing topic thread IDs grouped by user group (key: group, value: thread ID). Set to `0` to disable topics. |
+|messageThreadIds.default| *(Optional)* The thread ID of the default user group. Used for routing alerts into specific topics in Forum Supergroups.                  |
 
 ## reportPullAPI
 

--- a/src/reports/reportTelegram.js
+++ b/src/reports/reportTelegram.js
@@ -53,6 +53,7 @@ export default class reportTelegram extends ReportHTTP {
 
         super(channels, telegramParams, env);
         this.chatIds = params.chatIds;
+        this.messageThreadIds = params.messageThreadIds || null;
 
         if (!params.botUrl) {
             this.logger.log({
@@ -72,11 +73,27 @@ export default class reportTelegram extends ReportHTTP {
     };
 
     getTemplate = (group, channel, content) => {
-        return JSON.stringify({
+        const payload = {
             "chat_id": this.chatIds[group] || this.chatIds["default"],
             "text": "${summary}${markDownUrl}",
             "parse_mode": "markdown",
             "disable_web_page_preview": true
-        });
+        };
+
+        if (this.messageThreadIds) {
+            // Retrieve the thread ID for the specific group, falling back to the default group if undefined
+            const threadId = this.messageThreadIds[group] !== undefined ? this.messageThreadIds[group] : this.messageThreadIds["default"];
+            
+            if (threadId !== undefined && threadId !== null && threadId !== "") {
+                const parsedThreadId = parseInt(threadId, 10);
+                
+                // Only inject the parameter if it is a valid, non-zero topic ID
+                if (parsedThreadId !== 0 && !isNaN(parsedThreadId)) {
+                    payload["message_thread_id"] = parsedThreadId;
+                }
+            }
+        }
+
+        return JSON.stringify(payload);
     };
 }


### PR DESCRIPTION
Currently, the Telegram report module only supports sending alerts to standard chats, channels or groups. With Telegram's "Topics" feature for groups, it makes much more sense to route different alerts into specific topic threads rather than scattering them across multiple chats.

This approach is highly practical for maintaining a single, unified monitoring group. For example, you can have one central NOC group where BGPalerter, Uptime Kuma, and other infrastructure tools each get their own dedicated topic.

This PR adds an optional `messageThreadIds` parameter to the `reportTelegram` configuration to support this workflow.

### Changes made:
* Added the `messageThreadIds` block in `config.yml.example` (structurally mirroring `chatIds`).
* Updated `reportTelegram.js` to parse this new configuration and inject the `message_thread_id` key into the HTTP payload sent to the Telegram API.
* Added documentation for the new parameters in `docs/reports.md`.

### Backwards Compatibility:
I ensured this does not break existing configurations. The script strictly parses the ID as an integer. If `messageThreadIds` is omitted entirely, undefined, or explicitly set to `0`, the `message_thread_id` key is completely excluded from the payload object. It will safely fall back to standard group chat routing without throwing API errors.

I compiled and tested this locally and the alerts successfully route into the designated topics. Let me know if any adjustments are needed.