### PR TITLE
feat(Discord) Add Discord reporting support with customizable embed colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If the installation doesn't go smoothly, read [here](docs/installation.md). Read
         - [Announcements of new prefixes](docs/configuration.md#monitoras)
         - [Path matching](docs/configuration.md#monitorpath)
     - [Send alerts to](docs/reports.md#reports)
+        - [Discord](docs/reports.md#reportDiscord)
         - [File](docs/reports.md#reportfile)
         - [E-mail](docs/reports.md#reportemail)
         - [Slack](docs/reports.md#reportslack)

--- a/config.yml.example
+++ b/config.yml.example
@@ -159,6 +159,28 @@ reports:
 #        default: _YOUR_SLACK_WEBHOOK_URL_
 #        noc: _YOUR_SLACK_WEBHOOK_URL_
 
+#  - file: reportDiscord
+#    channels:
+#      - hijack
+#      - newprefix
+#      - visibility
+#      - path
+#      - misconfiguration
+#      - rpki
+#      - roa
+#    params:
+#      showPaths: 0 # Amount of AS_PATHs to report in the alert
+#      colors: # Optional, hex colors for the embed sidebar
+#        hijack: '#d60b1c'
+#        newprefix: '#fa9548'
+#        visibility: '#fad648'
+#        path: '#42cbf5'
+#        rpki: '#d892f0'
+#        roa: '#d892f0'
+#      hooks:
+#        default: _YOUR_DISCORD_WEBHOOK_URL_
+#        noc: _YOUR_DISCORD_WEBHOOK_URL_
+
 #  - file: reportKafka
 #    channels:
 #      - hijack

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -13,6 +13,7 @@ This will generate fake alerts. [Read more here](installation.md#bgpalerter-para
 - [reportFile](reports.md#reportFile)
 - [reportEmail](reports.md#reportEmail)
 - [reportSlack](reports.md#reportSlack)
+- [reportDiscord](reports.md#reportDiscord)
 - [reportKafka](reports.md#reportKafka)
 - [reportSyslog](reports.md#reportSyslog)
 - [reportAlerta](reports.md#reportAlerta)
@@ -63,6 +64,19 @@ Parameters for this report module:
 |colors| A dictionary having as key the event channel and as value a hex color (string). These colors will be used to make messages in Slack distinguishable. | 
 |showPaths| Amount of AS_PATHs to report in the alert (0 to disable). | 
 |hooks| A dictionary containing Slack WebHooks grouped by user group (key: group, value: WebHook).| 
+|hooks.default| The WebHook (URL) of the default user group.| 
+
+## reportDiscord
+
+This report module sends alerts on Discord as embeds, using [Discord webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks).
+
+Parameters for this report module:
+
+|Parameter| Description| 
+|---|---|
+|colors| A dictionary having as key the event channel and as value a hex color (string, e.g., `'#d60b1c'`). These colors will be used for the embed sidebar to make messages in Discord distinguishable. | 
+|showPaths| Amount of AS_PATHs to report in the alert (0 to disable). | 
+|hooks| A dictionary containing Discord WebHooks grouped by user group (key: group, value: WebHook).| 
 |hooks.default| The WebHook (URL) of the default user group.| 
 
 ## reportKafka

--- a/src/reports/reportDiscord.js
+++ b/src/reports/reportDiscord.js
@@ -1,0 +1,37 @@
+import ReportHTTP from "./reportHTTP";
+export default class ReportDiscord extends ReportHTTP {
+    constructor(channels, params, env) {
+        const templates = {};
+        const defaultColor = "#4287f5";
+        const colors = params.colors || {};
+        // Discord expects embed colors as decimal integers
+        const getColorDecimal = (color) => {
+            const decimal = parseInt(color.replace("#", ""), 16);
+            return isNaN(decimal) ? getColorDecimal(defaultColor) : decimal;
+        };
+        const getTemplateItem = (color) => {
+            return JSON.stringify({
+                embeds: [
+                    {
+                        title: "${channel}",
+                        description: "${summary}${markDownUrl}",
+                        color: getColorDecimal(color)
+                    }
+                ]
+            });
+        };
+        for (let channel of channels) {
+            templates[channel] = getTemplateItem(colors[channel] || defaultColor);
+        }
+        templates["default"] = getTemplateItem(defaultColor);
+        const discordParams = {
+            headers: {},
+            isTemplateJSON: true,
+            showPaths: params.showPaths,
+            hooks: params.hooks,
+            name: "reportDiscord",
+            templates
+        };
+        super(channels, discordParams, env);
+    }
+}


### PR DESCRIPTION
- Implemented a `reportDiscord` module for sending alerts to Discord via embeds.
- Updated the example `config.yml` to include `reportDiscord` configuration options.
- Enhanced documentation (`README.md` and `docs/reports.md`) with details about `reportDiscord` parameters and usage.